### PR TITLE
Re-add klog flags and add a deprecation message for soon-to-be-removed klog flags

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -17,24 +17,23 @@ limitations under the License.
 package main
 
 import (
-	"flag"
-
 	"github.com/cert-manager/cert-manager/cmd/controller/app"
 	"github.com/cert-manager/cert-manager/cmd/util"
 	logf "github.com/cert-manager/cert-manager/pkg/logs"
+	"github.com/spf13/pflag"
 )
 
 func main() {
 	stopCh, exit := util.SetupExitHandler(util.GracefulShutdown)
 	defer exit() // This function might call os.Exit, so defer last
 
-	logf.InitLogs(flag.CommandLine)
+	logf.InitLogs(pflag.CommandLine)
 	defer logf.FlushLogs()
 
 	cmd := app.NewCommandStartCertManagerController(stopCh)
-	cmd.Flags().AddGoFlagSet(flag.CommandLine)
+	cmd.Flags().AddFlagSet(pflag.CommandLine)
 
-	flag.CommandLine.Parse([]string{})
+	pflag.CommandLine.Parse([]string{})
 	if err := cmd.Execute(); err != nil {
 		logf.Log.Error(err, "error while executing")
 		util.SetExitCode(err)


### PR DESCRIPTION
Plan:

- **cert-manager 1.12** (end of April 2023): start of the deprecation period for the flags `--log_dir`, `--log_file`, `--log_flush_frequency`, `--logtostderr`, `--alsologtostderr`, `--one_output`, `--stderrthreshold`, `--log_file_max_size`, `--skip_log_headers`, `--add_dir_header`, `--skip_headers`, `--log_backtrace_at`.
- **cert-manager 1.15** (approx 6 month afterwards, Nov 2023): removal of the flags.

This PR adds a warning message that shows in two places:

- when using `--help`, the user will see the message `DEPRECATED: this flag will be removed in cert-manager 1.15`.
- when using one of the deprecated flags, the user will see a line warning them (unfortunately, this line isn't JSON formatted):
  ```
  $ go run ./cmd/controller --log_dir=/tmp --logging-format=json
  Flag --log_dir has been deprecated, this flag will be removed in cert-manager 1.15
  {"ts":1679413720180.1648,"caller":"clientcmd/client_config.go:618","msg":"Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.\n","v":0}
  ```

Before/after:

```diff
--- /tmp/before	2023-03-21 15:18:59.850741955 +0100
+++ /tmp/after	2023-03-21 16:46:37.725450622 +0100
@@ -16,8 +16,8 @@
       --acme-http01-solver-resource-request-cpu string      Defines the resource request CPU size when spawning new ACME HTTP01 challenge solver pods. (default "10m")
       --acme-http01-solver-resource-request-memory string   Defines the resource request Memory size when spawning new ACME HTTP01 challenge solver pods. (default "64Mi")
       --acme-http01-solver-run-as-non-root                  Defines the ability to run the http01 solver as root for troubleshooting issues (default true)
-      --add_dir_header                                      If true, adds the file directory to the header of the log messages
-      --alsologtostderr                                     log to standard error as well as files (no effect when -logtostderr=true)
+      --add_dir_header                                      If true, adds the file directory to the header of the log messages (DEPRECATED: this flag will be removed in cert-manager 1.15)
+      --alsologtostderr                                     log to standard error as well as files (no effect when -logtostderr=true) (DEPRECATED: this flag will be removed in cert-manager 1.15)
       --auto-certificate-annotations strings                The annotation consumed by the ingress-shim controller to indicate a ingress is requesting a certificate (default [kubernetes.io/tls-acme])
       --cluster-issuer-ambient-credentials                  Whether a cluster-issuer may make use of ambient credentials for issuers. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the ClusterIssuer API object. When this flag is enabled, the following sources for credentials are also used: AWS - All sources the Go SDK defaults to, notably including any EC2 IAM roles available via instance metadata. (default true)
       --cluster-resource-namespace string                   Namespace to store resources owned by cluster scoped resources such as ClusterIssuer in. This must be specified if ClusterIssuers are enabled. (default "kube-system")
@@ -54,19 +54,22 @@
       --leader-election-renew-deadline duration             The interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled. (default 40s)
       --leader-election-retry-period duration               The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled. (default 15s)
       --log-flush-frequency duration                        Maximum number of seconds between log flushes (default 5s)
-      --log_backtrace_at traceLocation                      when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                                      If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                                     If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint                              Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                                         log to standard error instead of files (default true)
+      --log-json-info-buffer-size quantity                  [Alpha] In JSON format with split output streams, the info messages can be buffered for a while to increase performance. The default value of zero bytes disables buffering. The size can be specified as number of bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers of those (3M, 4G, 5Mi, 6Gi). Enable the LoggingAlphaOptions feature gate to use this.
+      --log-json-split-stream                               [Alpha] In JSON format, write error messages to stderr and info messages to stdout. The default is to write a single stream to stdout. Enable the LoggingAlphaOptions feature gate to use this.
+      --log_backtrace_at traceLocation                      when logging hits line file:N, emit a stack trace (default :0) (DEPRECATED: this flag will be removed in cert-manager 1.15)
+      --log_dir string                                      If non-empty, write log files in this directory (no effect when -logtostderr=true) (DEPRECATED: this flag will be removed in cert-manager 1.15)
+      --log_file string                                     If non-empty, use this log file (no effect when -logtostderr=true) (DEPRECATED: this flag will be removed in cert-manager 1.15)
+      --log_file_max_size uint                              Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800) (DEPRECATED: this flag will be removed in cert-manager 1.15)
+      --logging-format string                               Sets the log format. Permitted formats: "json" (gated by LoggingBetaOptions), "text". (default "text")
+      --logtostderr                                         log to standard error instead of files (default true) (DEPRECATED: this flag will be removed in cert-manager 1.15)
       --master string                                       Optional apiserver host address to connect to. If not specified, autoconfiguration will be attempted.
       --max-concurrent-challenges int                       The maximum number of challenges that can be scheduled as 'processing' at once. (default 60)
       --metrics-listen-address string                       The host and port that the metrics endpoint should listen on. (default "0.0.0.0:9402")
       --namespace string                                    If set, this limits the scope of cert-manager to a single namespace and ClusterIssuers are disabled. If not specified, all namespaces will be watched
-      --one_output                                          If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
+      --one_output                                          If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true) (DEPRECATED: this flag will be removed in cert-manager 1.15)
       --profiler-address string                             The host and port that Go profiler should listen on, i.e localhost:6060. Ensure that profiler is not exposed on a public address. Profiler will be served at /debug/pprof. (default "localhost:6060")
-      --skip_headers                                        If true, avoid header prefixes in the log messages
-      --skip_log_headers                                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --stderrthreshold severity                            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
+      --skip_headers                                        If true, avoid header prefixes in the log messages (DEPRECATED: this flag will be removed in cert-manager 1.15)
+      --skip_log_headers                                    If true, avoid headers when opening log files (no effect when -logtostderr=true) (DEPRECATED: this flag will be removed in cert-manager 1.15)
+      --stderrthreshold severity                            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2) (DEPRECATED: this flag will be removed in cert-manager 1.15)
   -v, --v Level                                             number for the log level verbosity
-      --vmodule moduleSpec                                  comma-separated list of pattern=N settings for file-filtered logging
+      --vmodule pattern=N,...                               comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
```